### PR TITLE
docs: standardized CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,27 @@
+# Contributing
+
+Contributions are welcome. By participating, you agree to maintain a respectful and constructive environment.
+
+For coding standards, testing patterns, architecture guidelines, commit conventions, and all
+development practices, refer to the **[Development Guide](https://github.com/rios0rios0/guide/wiki)**.
+
+## Prerequisites
+
+- [JDK](https://adoptium.net/) 8+
+- [Maven](https://maven.apache.org/) 3+
+
+## Development Workflow
+
+1. Fork and clone the repository
+2. Create a branch: `git checkout -b feat/my-change`
+3. Build the project:
+   ```bash
+   mvn clean install
+   ```
+4. Make your changes
+5. Run tests:
+   ```bash
+   mvn test
+   ```
+6. Commit following the [commit conventions](https://github.com/rios0rios0/guide/wiki/Life-Cycle/Git-Flow)
+7. Open a pull request against `main`

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The REST service will start on the default Spring Boot port.
 
 ## Contributing
 
-Contributions are welcome! Please open an issue or submit a pull request.
+Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 
 ## License
 


### PR DESCRIPTION
## Summary

- added standardized `CONTRIBUTING.md` referencing the [Development Guide](https://github.com/rios0rios0/guide/wiki) for all coding standards and conventions
- updated `README.md` Contributing section to link to `CONTRIBUTING.md`

## Test plan

- [ ] verify `CONTRIBUTING.md` renders correctly on GitHub
- [ ] verify `README.md` links to `CONTRIBUTING.md` correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)