### PR TITLE
fix(ci): fixed missing package reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 - added GitHub Actions workflow for CI/CD pipeline
 
+### Fixed
+
+- fixed compilation error caused by missing external package `br.gov.ba.alba.app.config.exceptions` by creating a local `ObjectNotFoundException` class
+
 ### Removed
 
 - removed Travis CI configuration in favor of GitHub Actions

--- a/src/main/java/com/services/ObjectNotFoundException.java
+++ b/src/main/java/com/services/ObjectNotFoundException.java
@@ -1,0 +1,15 @@
+package com;
+
+/**
+ * Exception thrown when a requested object is not found in the remote service.
+ */
+public class ObjectNotFoundException extends RuntimeException {
+
+    public ObjectNotFoundException(String message) {
+        super(message);
+    }
+
+    public ObjectNotFoundException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/services/RestService.java
+++ b/src/main/java/com/services/RestService.java
@@ -1,6 +1,5 @@
 package com;
 
-import br.gov.ba.alba.app.config.exceptions.ObjectNotFoundException;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JavaType;


### PR DESCRIPTION
## Summary

- Created a local ObjectNotFoundException class to replace the broken external dependency on br.gov.ba.alba.app.config.exceptions
- Removed the non-existent package import from RestService.java that caused the Maven compilation error
- Updated CHANGELOG.md with the fix entry

## Context

The CI workflow was failing on both the maven-verify and codeql jobs because RestService.java imported br.gov.ba.alba.app.config.exceptions.ObjectNotFoundException, a package from an unrelated project that was never part of this repository dependencies.

The fix creates a local ObjectNotFoundException extending RuntimeException in the same com package, so the existing usage in requestErrorHandle() works without any other changes.

Note: The Trivy SCA job also fails due to known CVEs in old dependencies (Spring Boot 2.1.0, httpcomponents 4.x, etc.). Upgrading these dependencies is a separate effort and not addressed in this PR.

## Test plan

- [ ] Verify the maven-verify job passes (compilation succeeds)
- [ ] Verify the codeql job passes (autobuild succeeds)
- [ ] Confirm the Trivy SCA failure is unrelated to this change (pre-existing dependency CVEs)