### PR TITLE
chore(refresh): refreshed configuration and documentation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-`rest-arch` is a RESTful architecture reference project built with **Java 8** and **Spring Boot 2.1**. It provides an abstract `RestService<T>` base class that encapsulates common patterns for consuming REST APIs (GET, POST, JSON deserialization, error handling), intended to be extended by concrete service classes in applications that integrate with external REST backends.
+`rest-arch` is a RESTful architecture reference **library** built with **Java 21** and **Spring Boot 3.4**. It provides an abstract `RestService<T>` base class that encapsulates common patterns for consuming REST APIs (GET, POST, JSON deserialization, error handling), intended to be extended by concrete service classes in applications that integrate with external REST backends. This is a library JAR, not a bootable application — there is no `spring-boot-maven-plugin`.
 
 ## Repository Structure
 
@@ -13,7 +13,8 @@
 src/
   main/
     java/com/services/
-      RestService.java         # Abstract generic REST client base class
+      ObjectNotFoundException.java  # Custom exception for 404 responses
+      RestService.java              # Abstract generic REST client base class
     resources/
       application.properties   # Spring Boot application configuration (port 8080)
   test/
@@ -26,13 +27,13 @@ CHANGELOG.md                   # Version history following Keep a Changelog
 
 ## Technology Stack
 
-- **Language**: Java 8
-- **Framework**: Spring Boot 2.1.0.RELEASE (spring-boot-starter-web)
-- **Build**: Apache Maven 3.6+
-- **HTTP clients**: Spring `RestTemplate`, OkHttp 4.9.2, Apache HttpClient 4.5.x
-- **JSON**: Jackson Databind, Gson 2.8.9
-- **Utilities**: Guava 32.0.0-jre, Joda-Time 2.9.9
-- **Testing**: JUnit 4.13.1, spring-boot-starter-test
+- **Language**: Java 21
+- **Framework**: Spring Boot 3.4.13 (spring-boot-starter-web)
+- **Build**: Apache Maven
+- **HTTP clients**: Spring `RestTemplate`, OkHttp 5.3.2, Apache HttpComponents Client 5.x
+- **JSON**: Jackson Databind, Gson (Spring Boot managed)
+- **Utilities**: Guava 33.6.0-jre, Joda-Time 2.14.1
+- **Testing**: JUnit 4.13.2, spring-boot-starter-test
 - **CI/CD**: GitHub Actions — delegates to `rios0rios0/pipelines/.github/workflows/java-maven.yaml@main`
 
 ## Build, Test, and Run Commands
@@ -41,13 +42,10 @@ CHANGELOG.md                   # Version history following Keep a Changelog
 # Install dependencies and compile (runs tests by default)
 mvn clean install
 
-# Run only the test suite (~seconds on first run, faster on warm cache)
+# Run only the test suite
 mvn test
 
-# Start the Spring Boot application locally (listens on port 8080)
-mvn spring-boot:run
-
-# Package an executable JAR without running tests
+# Package the library JAR without running tests
 mvn package -DskipTests
 ```
 
@@ -61,16 +59,15 @@ mvn package -DskipTests
 
 ## CI/CD Pipeline
 
-The `.github/workflows/default.yaml` triggers on pushes and PRs to `main` and on all tags. It reuses the organisation-wide reusable workflow at `rios0rios0/pipelines/.github/workflows/java-maven.yaml@main`, which handles compilation, testing, and artefact publishing automatically.
+The `.github/workflows/default.yaml` triggers on pushes and PRs to `main`, on all tags, and on manual dispatch. It reuses the organisation-wide reusable workflow at `rios0rios0/pipelines/.github/workflows/java-maven.yaml@main`, which handles compilation, testing, and artefact publishing automatically.
 
 ## Development Workflow
 
 1. Fork the repository and create a feature branch: `git checkout -b feat/my-change`
 2. Build and verify: `mvn clean install`
-3. Run the application locally: `mvn spring-boot:run`
-4. Run tests: `mvn test`
-5. Commit using [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `chore:`, etc.) following the [rios0rios0 Git Flow guide](https://github.com/rios0rios0/guide/wiki/Life-Cycle/Git-Flow)
-6. Open a pull request against `main`
+3. Run tests: `mvn test`
+4. Commit using [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `chore:`, etc.) following the [rios0rios0 Git Flow guide](https://github.com/rios0rios0/guide/wiki/Life-Cycle/Git-Flow)
+5. Open a pull request against `main`
 
 ## Coding Conventions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Added
+
+- added `CLAUDE.md` with build commands, architecture notes, and conventions for Claude Code sessions
+
+### Changed
+
+- refreshed `.github/copilot-instructions.md` to reflect Java 21, Spring Boot 3.4, updated dependency versions, and library (non-bootable) project status
+
 ## [0.1.1] - 2026-04-15
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,36 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+`rest-arch` is a Java 21 / Spring Boot 3.4 **library** (not a bootable application). It provides an abstract `RestService<T extends Serializable>` base class for consuming REST APIs. There is no `spring-boot-maven-plugin` — you cannot run `mvn spring-boot:run`.
+
+## Build and test
+
+```bash
+mvn clean install   # compile + test
+mvn test            # tests only
+mvn package -DskipTests  # JAR without tests
+```
+
+## Architecture
+
+- `RestService<T>` resolves its generic type via reflection at construction time. Concrete subclasses inherit typed `getForEntity`, `getForList`, `postForEntity`, `postForList` methods.
+- Base URL injected via `@Value("${app.restservice.base}")`.
+- `ObjectNotFoundException` thrown on 404; error messages resolved through `MessageSource` + `LocaleContextHolder`.
+- Package root is `com`; services live under `com.services`.
+
+## Key dependencies
+
+Spring Boot 3.4.13, OkHttp 5.3.2, Apache HttpComponents Client 5.x, Guava 33.6.0-jre, Joda-Time 2.14.1, JUnit 4.13.2. Jackson and Gson versions are Spring Boot managed.
+
+## Conventions
+
+- Conventional Commits (`feat:`, `fix:`, `chore:`) following [rios0rios0 Git Flow](https://github.com/rios0rios0/guide/wiki/Life-Cycle/Git-Flow).
+- `null` checks use `Objects.isNull` / `Objects.nonNull`.
+- SLF4J logging via `LoggerFactory.getLogger(getClass())`.
+
+## CI
+
+GitHub Actions (`.github/workflows/default.yaml`) delegates to `rios0rios0/pipelines/.github/workflows/java-maven.yaml@main`.


### PR DESCRIPTION
Automated weekly refresh by `config-and-docs-refresh.yaml` in `rios0rios0/config-automation`.

Claude Code reviewed the in-scope configuration and documentation files (currently `CLAUDE.md` and `.github/copilot-instructions.md`) against the current code, updated whichever drifted, and recorded the change in `CHANGELOG.md` (when the repo has one).

Review the diff carefully --- this PR was generated by Claude Code and may contain inaccuracies.