### PR TITLE
chore(refresh): refreshed configuration and documentation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -32,9 +32,9 @@ CHANGELOG.md                   # Version history following Keep a Changelog
 - **Build**: Apache Maven
 - **HTTP clients**: Spring `RestTemplate`, OkHttp 5.3.2, Apache HttpComponents Client 5.x
 - **JSON**: Jackson Databind, Gson (Spring Boot managed)
-- **Utilities**: Guava 33.6.0-jre, Joda-Time 2.14.1
+- **Utilities**: Guava 33.6.0-jre, Joda-Time 2.14.2
 - **Testing**: JUnit 4.13.2, spring-boot-starter-test
-- **CI/CD**: GitHub Actions — delegates to `rios0rios0/pipelines/.github/workflows/java-maven.yaml@main`
+- **CI/CD**: GitHub Actions — delegates to `rios0rios0/pipelines/.github/workflows/maven-library.yaml@main`
 
 ## Build, Test, and Run Commands
 
@@ -59,7 +59,7 @@ mvn package -DskipTests
 
 ## CI/CD Pipeline
 
-The `.github/workflows/default.yaml` triggers on pushes and PRs to `main`, on all tags, and on manual dispatch. It reuses the organisation-wide reusable workflow at `rios0rios0/pipelines/.github/workflows/java-maven.yaml@main`, which handles compilation, testing, and artefact publishing automatically.
+The `.github/workflows/default.yaml` triggers on pushes and PRs to `main`, on all tags, and on manual dispatch. It reuses the organisation-wide reusable workflow at `rios0rios0/pipelines/.github/workflows/maven-library.yaml@main`, which handles compilation, testing, and artefact publishing automatically.
 
 ## Development Workflow
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 ### Changed
 
 - changed the Java dependencies to their latest versions
+- refreshed `CLAUDE.md` and `.github/copilot-instructions.md` to fix Joda-Time version (2.14.1 → 2.14.2) and CI workflow name (java-maven.yaml → maven-library.yaml)
 
 ## [0.2.1] - 2026-04-29
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ mvn package -DskipTests  # JAR without tests
 
 ## Key dependencies
 
-Spring Boot 3.4.13, OkHttp 5.3.2, Apache HttpComponents Client 5.x, Guava 33.6.0-jre, Joda-Time 2.14.1, JUnit 4.13.2. Jackson and Gson versions are Spring Boot managed.
+Spring Boot 3.4.13, OkHttp 5.3.2, Apache HttpComponents Client 5.x, Guava 33.6.0-jre, Joda-Time 2.14.2, JUnit 4.13.2. Jackson and Gson versions are Spring Boot managed.
 
 ## Conventions
 
@@ -33,4 +33,4 @@ Spring Boot 3.4.13, OkHttp 5.3.2, Apache HttpComponents Client 5.x, Guava 33.6.0
 
 ## CI
 
-GitHub Actions (`.github/workflows/default.yaml`) delegates to `rios0rios0/pipelines/.github/workflows/java-maven.yaml@main`.
+GitHub Actions (`.github/workflows/default.yaml`) delegates to `rios0rios0/pipelines/.github/workflows/maven-library.yaml@main`.


### PR DESCRIPTION
Automated weekly refresh by `config-and-docs-refresh.yaml` in `rios0rios0/config-automation`.

Claude Code reviewed the in-scope configuration and documentation files (currently `CLAUDE.md` and `.github/copilot-instructions.md`) against the current code, updated whichever drifted, and recorded the change in `CHANGELOG.md` (when the repo has one).

Review the diff carefully --- this PR was generated by Claude Code and may contain inaccuracies.