### PR TITLE
chore(refresh): refreshed configuration and documentation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-`rest-arch` is a RESTful architecture reference **library** built with **Java 21** and **Spring Boot 3.4**. It provides an abstract `RestService<T>` base class that encapsulates common patterns for consuming REST APIs (GET, POST, JSON deserialization, error handling), intended to be extended by concrete service classes in applications that integrate with external REST backends. This is a library JAR, not a bootable application — there is no `spring-boot-maven-plugin`.
+`rest-arch` is a RESTful architecture reference **library** built with **Java 21** and **Spring Boot 3.5**. It provides an abstract `RestService<T>` base class that encapsulates common patterns for consuming REST APIs (GET, POST, JSON deserialization, error handling), intended to be extended by concrete service classes in applications that integrate with external REST backends. This is a library JAR, not a bootable application — there is no `spring-boot-maven-plugin`.
 
 ## Repository Structure
 
@@ -28,7 +28,7 @@ CHANGELOG.md                   # Version history following Keep a Changelog
 ## Technology Stack
 
 - **Language**: Java 21
-- **Framework**: Spring Boot 3.4.13 (spring-boot-starter-web)
+- **Framework**: Spring Boot 3.5.14 (spring-boot-starter-web)
 - **Build**: Apache Maven
 - **HTTP clients**: Spring `RestTemplate`, OkHttp 5.3.2, Apache HttpComponents Client 5.x
 - **JSON**: Jackson Databind, Gson (Spring Boot managed)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 ### Changed
 
 - changed the Java dependencies to their latest stable versions
+- refreshed `CLAUDE.md` and `.github/copilot-instructions.md` to reflect the Spring Boot parent bump from `3.4.13` to `3.5.14`
 
 ### Security
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What this is
 
-`rest-arch` is a Java 21 / Spring Boot 3.4 **library** (not a bootable application). It provides an abstract `RestService<T extends Serializable>` base class for consuming REST APIs. There is no `spring-boot-maven-plugin` — you cannot run `mvn spring-boot:run`.
+`rest-arch` is a Java 21 / Spring Boot 3.5 **library** (not a bootable application). It provides an abstract `RestService<T extends Serializable>` base class for consuming REST APIs. There is no `spring-boot-maven-plugin` — you cannot run `mvn spring-boot:run`.
 
 ## Build and test
 
@@ -23,7 +23,7 @@ mvn package -DskipTests  # JAR without tests
 
 ## Key dependencies
 
-Spring Boot 3.4.13, OkHttp 5.3.2, Apache HttpComponents Client 5.x, Guava 33.6.0-jre, Joda-Time 2.14.2, JUnit 4.13.2. Jackson and Gson versions are Spring Boot managed.
+Spring Boot 3.5.14, OkHttp 5.3.2, Apache HttpComponents Client 5.x, Guava 33.6.0-jre, Joda-Time 2.14.2, JUnit 4.13.2. Jackson and Gson versions are Spring Boot managed.
 
 ## Conventions
 


### PR DESCRIPTION
Automated weekly refresh by `config-and-docs-refresh.yaml` in `rios0rios0/config-automation`.

Claude Code reviewed the in-scope configuration and documentation files (currently `CLAUDE.md` and `.github/copilot-instructions.md`) against the current code, updated whichever drifted, and recorded the change in `CHANGELOG.md` (when the repo has one).

Review the diff carefully --- this PR was generated by Claude Code and may contain inaccuracies.