### PR TITLE
chore(refresh): refreshed configuration and documentation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -30,7 +30,7 @@ CHANGELOG.md                   # Version history following Keep a Changelog
 - **Language**: Java 21
 - **Framework**: Spring Boot 3.5.14 (spring-boot-starter-web)
 - **Build**: Apache Maven
-- **HTTP clients**: Spring `RestTemplate`, OkHttp 5.3.2, Apache HttpComponents Client 5.x
+- **HTTP clients**: Spring `RestTemplate`, OkHttp 5.4.0, Apache HttpComponents Client 5.x
 - **JSON**: Jackson Databind, Gson (Spring Boot managed)
 - **Utilities**: Guava 33.6.0-jre, Joda-Time 2.14.2
 - **Testing**: JUnit 4.13.2, spring-boot-starter-test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Changed
+
+- refreshed `CLAUDE.md` and `.github/copilot-instructions.md` to correct the OkHttp version (`5.3.2` → `5.4.0`)
+
 ## [0.2.5] - 2026-06-09
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ mvn package -DskipTests  # JAR without tests
 
 ## Key dependencies
 
-Spring Boot 3.5.14, OkHttp 5.3.2, Apache HttpComponents Client 5.x, Guava 33.6.0-jre, Joda-Time 2.14.2, JUnit 4.13.2. Jackson and Gson versions are Spring Boot managed.
+Spring Boot 3.5.14, OkHttp 5.4.0, Apache HttpComponents Client 5.x, Guava 33.6.0-jre, Joda-Time 2.14.2, JUnit 4.13.2. Jackson and Gson versions are Spring Boot managed.
 
 ## Conventions
 


### PR DESCRIPTION
Automated weekly refresh by `config-and-docs-refresh.yaml` in `rios0rios0/config-automation`.

Claude Code reviewed the in-scope configuration and documentation files (currently `CLAUDE.md` and `.github/copilot-instructions.md`) against the current code, updated whichever drifted, and recorded the change in `CHANGELOG.md` (when the repo has one).

Review the diff carefully --- this PR was generated by Claude Code and may contain inaccuracies.